### PR TITLE
Update openapi.yaml

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7,8 +7,6 @@ info:
     som mener noe om produksjonsplasser
   title: Endringsservice
   version: 1.0.0
-servers:
-- url: https://raw.githubusercontent.com/eljarh/api-spec/main/https
 paths:
   /produksjonsplass:
     post:


### PR DESCRIPTION
removed servers as it points to a 404, and to test out if it impacts openapi.json generation in Mattilsynet/endringsservice.